### PR TITLE
fix(dl): using slug as dir name

### DIFF
--- a/internal/resolvers/hanimetv/hanimetv.go
+++ b/internal/resolvers/hanimetv/hanimetv.go
@@ -82,7 +82,7 @@ func (re *resolver) Resolve(u string, opt *resolvers.Option) ([]*resolvers.HAnim
 		episodes = append(episodes, eps[0])
 		res = append(res, &resolvers.HAnime{
 			Site:   site,
-			Title:  video.HentaiFranchise.Title,
+			Title:  video.HentaiFranchise.Slug,
 			Videos: vidMap,
 		})
 	}


### PR DESCRIPTION
Fixes #17 
### Description
- Use video slug as directory name to avoid forbidden characters on Windows